### PR TITLE
PARTICIPANT is named "name"

### DIFF
--- a/sdk/src/java/com/ifountain/opsgenie/client/OpsGenieClientConstants.java
+++ b/sdk/src/java/com/ifountain/opsgenie/client/OpsGenieClientConstants.java
@@ -79,7 +79,7 @@ public interface OpsGenieClientConstants {
         public static final String SORT_BY = "sortBy";
         public static final String ORDER = "order";
         public static final String LIMIT = "limit";
-        public static final String PARTICIPANT = "participant";
+        public static final String PARTICIPANT = "name";
         public static final String LAST_HEARTBEAT = "lastHeartbeat";
         public static final String EXPIRED = "expired";
         public static final String SOURCES = "sources";


### PR DESCRIPTION
Fixes WhoIsOnCall family of functions/interfaces response. In `participants` array in [response](http://support.opsgenie.com/customer/portal/articles/1102279-schedule-api#whoIsOncallRequest), 
the participant's name has the key 'name' and not 'participant' in the objects.
