### PR TITLE
Make marid init script chkconfig compliant

### DIFF
--- a/common/native/marid_rpm
+++ b/common/native/marid_rpm
@@ -3,6 +3,9 @@
 # marid    Startup script for the marid
 #
 # chkconfig: 2345 90 10
+# description: Marid is an OpsGenie tool to integrate nagios
+# processname: marid
+# config: /etc/opsgenie/opsgenie.cfg
 # pidfile: /var/run/marid.pid
 
 # Source function library


### PR DESCRIPTION
This patch adds extra chkconfig information to avoid the following error when enabling _marid_ at boot time via `chkconfig marid on`. This patch only affects the init script for RPM based distros.

On a Centos 5, you would get the following without the patch
```
# chkconfig marid on
service marid does not support chkconfig
```