### PR TITLE
Updating Log4j and Gradle versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## 2.13.0 (December 21, 2021)
+* Gradle version increased to 4.8.1
+* Log4j updated to 2.17.0
+* Removed support of Marid logging to a path

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 The project includes:
 
 * Java SDK
-* Marid
+* Marid (Deprecated)
 
 ## Java SDK For Maven and Gradle
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,7 +9,9 @@ dependencies {
 
     compile 'bsf:bsf:2.4.0'
     compile 'org.codehaus.groovy:groovy-all:1.8.4'
-    compile 'log4j:log4j:1.2.16'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.0'
     testCompile project(':test')
     compile 'com.opsgenie.oas:opsgenie-sdk-swagger:1.0.10'
 }

--- a/common/src/main/java/com/ifountain/opsgenie/client/script/AsyncScriptManager.java
+++ b/common/src/main/java/com/ifountain/opsgenie/client/script/AsyncScriptManager.java
@@ -1,7 +1,8 @@
 package com.ifountain.opsgenie.client.script;
 
 import com.ifountain.opsgenie.client.script.util.OpsGenieExecutorsUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.*;
@@ -19,7 +20,7 @@ public class AsyncScriptManager {
     private ExecutorService scriptExecutionService;
     private BlockingQueue<Runnable> workQueue;
     private long shutdownWaitTime = DEFAULT_SHUTDOWN_WAIT_TIME;
-    private Logger logger = Logger.getLogger(AsyncScriptManager.class);
+    private Logger logger = LoggerFactory.getLogger(AsyncScriptManager.class);
     private boolean initialized = false;
 
     private AsyncScriptManager() {

--- a/common/src/main/java/com/ifountain/opsgenie/client/script/ScriptManager.java
+++ b/common/src/main/java/com/ifountain/opsgenie/client/script/ScriptManager.java
@@ -4,7 +4,8 @@ import groovy.lang.GroovyClassLoader;
 import org.apache.bsf.BSFException;
 import org.apache.bsf.BSFManager;
 import org.apache.bsf.util.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileReader;
@@ -52,7 +53,7 @@ public class ScriptManager {
         if (!scriptFile.exists()) {
             throw new Exception("Script [" + scriptPath + "] does not exist.");
         }
-        Logger logger = Logger.getLogger("script." + scriptPath);
+        final Logger logger = LoggerFactory.getLogger("script." + scriptPath);
         bindings.put(OpsgenieClientApplicationConstants.ScriptProxy.BINDING_LOGGER, logger);
         String lang = BSFManager.getLangFromFilename(scriptFile.getName());
         FileReader fin = null;

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Tue Jan 20 11:03:14 EET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip

--- a/gradlew
+++ b/gradlew
@@ -1,51 +1,10 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ##############################################################################
 ##
 ##  Gradle start up script for UN*X
 ##
 ##############################################################################
-
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
-
-APP_NAME="Gradle"
-APP_BASE_NAME=`basename "$0"`
-
-# Use the maximum available, or set MAX_FD != -1 to use that value.
-MAX_FD="maximum"
-
-warn ( ) {
-    echo "$*"
-}
-
-die ( ) {
-    echo
-    echo "$*"
-    echo
-    exit 1
-}
-
-# OS specific support (must be 'true' or 'false').
-cygwin=false
-msys=false
-darwin=false
-case "`uname`" in
-  CYGWIN* )
-    cygwin=true
-    ;;
-  Darwin* )
-    darwin=true
-    ;;
-  MINGW* )
-    msys=true
-    ;;
-esac
-
-# For Cygwin, ensure paths are in UNIX format before anything is touched.
-if $cygwin ; then
-    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-fi
 
 # Attempt to set APP_HOME
 # Resolve links: $0 may be a link
@@ -61,9 +20,49 @@ while [ -h "$PRG" ] ; do
     fi
 done
 SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >&-
+cd "`dirname \"$PRG\"`/" >/dev/null
 APP_HOME="`pwd -P`"
-cd "$SAVED" >&-
+cd "$SAVED" >/dev/null
+
+APP_NAME="Gradle"
+APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn () {
+    echo "$*"
+}
+
+die () {
+    echo
+    echo "$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
@@ -90,7 +89,7 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`
     if [ $? -eq 0 ] ; then
         if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
@@ -114,6 +113,7 @@ fi
 if $cygwin ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath
     ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
@@ -154,11 +154,19 @@ if $cygwin ; then
     esac
 fi
 
-# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
-function splitJvmOpts() {
-    JVM_OPTS=("$@")
+# Escape application args
+save () {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
 }
-eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
-JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+APP_ARGS=$(save "$@")
 
-exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
+  cd "$(dirname "$0")"
+fi
+
+exec "$JAVACMD" "$@"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -8,13 +8,13 @@
 @rem Set local scope for the variables with windows NT shell
 if "%OS%"=="Windows_NT" setlocal
 
-@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
-
 set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
@@ -46,10 +46,9 @@ echo location of your Java installation.
 goto fail
 
 :init
-@rem Get command-line arguments, handling Windowz variants
+@rem Get command-line arguments, handling Windows variants
 
 if not "%OS%" == "Windows_NT" goto win9xME_args
-if "%@eval[2+2]" == "4" goto 4NT_args
 
 :win9xME_args
 @rem Slurp the command line arguments.
@@ -60,11 +59,6 @@ set _SKIP=2
 if "x%~1" == "x" goto execute
 
 set CMD_LINE_ARGS=%*
-goto execute
-
-:4NT_args
-@rem Get arguments from the 4NT Shell from JP Software
-set CMD_LINE_ARGS=%$
 
 :execute
 @rem Setup the command line

--- a/marid/src/main/java/com/ifountain/opsgenie/client/marid/Bootstrap.java
+++ b/marid/src/main/java/com/ifountain/opsgenie/client/marid/Bootstrap.java
@@ -13,7 +13,9 @@ import com.ifountain.opsgenie.client.script.ScriptManager;
 import com.ifountain.opsgenie.client.util.JsonUtils;
 import com.ifountain.opsgenie.client.util.ManifestUtils;
 import org.apache.http.HttpStatus;
-import org.apache.log4j.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 import java.io.File;
 import java.util.*;
@@ -29,7 +31,7 @@ public class Bootstrap {
     public static final String MARID_CONF_DIR_SYSTEM_PROPERTY = "marid.conf.dir";
     public static final String CONF_PATH_SYSTEM_PROPERTY = "marid.conf.path";
     public static final String LOG_PATH_SYSTEM_PROPERTY = "marid.log.conf.path";
-    protected Logger logger = Logger.getLogger(Bootstrap.class);
+    protected Logger logger = LoggerFactory.getLogger(Bootstrap.class);
     private HttpProxy proxy;
     private HttpServer httpServer;
     private HttpServer httpsServer;
@@ -253,34 +255,7 @@ public class Bootstrap {
     }
 
     private void configureLogger() {
-        File logConfigFile = new File(getLogConfigurationFilePath());
-
-        // if doesn't exist look in home dir
-        if(!logConfigFile.exists())
-            logConfigFile = new File("conf/log.properties");
-
-        if (logConfigFile.exists()) {
-            Enumeration currentCategories = LogManager.getCurrentLoggers();
-            Map<Category, List<Appender>> allAppenders = new HashMap<Category, List<Appender>>();
-            while (currentCategories.hasMoreElements()) {
-                List<Appender> categoryAppenders = new ArrayList<Appender>();
-                Category category = (Category) currentCategories.nextElement();
-                Enumeration appenders = category.getAllAppenders();
-                while (appenders.hasMoreElements()) {
-                    categoryAppenders.add((Appender) appenders.nextElement());
-                }
-                allAppenders.put(category, categoryAppenders);
-            }
-            PropertyConfigurator.configure(logConfigFile.getPath());
-            for (Map.Entry<Category, List<Appender>> appenders : allAppenders.entrySet()) {
-                for (Appender appender : appenders.getValue()) {
-                    appenders.getKey().removeAppender(appender);
-                }
-            }
-            logger.info(getLogPrefix() + "Log configuration is loaded.");
-        } else {
-            logger.warn(getLogPrefix() + "No log configuration file exists.");
-        }
+        File logConfigFile  = new File("conf/log.properties");
     }
 
 

--- a/marid/src/main/java/com/ifountain/opsgenie/client/marid/alert/PubnubAlertActionListener.java
+++ b/marid/src/main/java/com/ifountain/opsgenie/client/marid/alert/PubnubAlertActionListener.java
@@ -8,8 +8,9 @@ import com.ning.http.client.ProxyServer;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.message.BasicNameValuePair;
-import org.apache.log4j.Logger;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import pubnub.api.Callback;
 import pubnub.api.Pubnub;
 
@@ -32,7 +33,7 @@ public class PubnubAlertActionListener {
     private PubnubAlertActionListener() {
     }
 
-    private Logger logger = Logger.getLogger(PubnubAlertActionListener.class);
+    private Logger logger = LoggerFactory.getLogger(PubnubAlertActionListener.class);
     private Pubnub pubnub;
     private PubnubChannelParameters pubnubChannelParameters;
     private Thread pubnubSubscribeThread;

--- a/marid/src/main/java/com/ifountain/opsgenie/client/marid/http/HttpServer.java
+++ b/marid/src/main/java/com/ifountain/opsgenie/client/marid/http/HttpServer.java
@@ -1,7 +1,6 @@
 package com.ifountain.opsgenie.client.marid.http;
 
 import com.ifountain.opsgenie.client.util.JsonUtils;
-import org.apache.log4j.Logger;
 import org.jboss.netty.bootstrap.ServerBootstrap;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -19,6 +18,8 @@ import org.jboss.netty.handler.timeout.*;
 import org.jboss.netty.util.CharsetUtil;
 import org.jboss.netty.util.HashedWheelTimer;
 import org.jboss.netty.util.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -48,9 +49,9 @@ public class HttpServer {
     private ChannelGroup allChannels;
     private int maxContentLength = 100 * 1024 * 1024;
     private int threadPoolSize = 100;
-    private Logger logger = Logger.getLogger(HttpServer.class);
-    private Logger requestLogger = Logger.getLogger(HttpServer.class.getName() + ".request");
-    private Logger requestWithExceptionLogger = Logger.getLogger(HttpServer.class.getName() + ".request.exception");
+    private Logger logger = LoggerFactory.getLogger(HttpServer.class);
+    private Logger requestLogger = LoggerFactory.getLogger(HttpServer.class.getName() + ".request");
+    private Logger requestWithExceptionLogger = LoggerFactory.getLogger(HttpServer.class.getName() + ".request.exception");
     private long timeout;
     private boolean sslEnabled = false;
     private String keystorePath;

--- a/test/src/main/groovy/com/ifountain/opsgenie/client/test/util/logging/TestLogUtils.groovy
+++ b/test/src/main/groovy/com/ifountain/opsgenie/client/test/util/logging/TestLogUtils.groovy
@@ -2,10 +2,11 @@
 * Created on Jan 21, 2008
 *
 */
-package com.ifountain.opsgenie.client.test.util.logging;
+package com.ifountain.opsgenie.client.test.util.logging
 
-import org.apache.log4j.Level
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.Level
+import org.slf4j.Logger;
+
 
 public class TestLogUtils {
     public static Logger log = Logger.getLogger(TestLogUtils.class);


### PR DESCRIPTION
This  PR will do following things
1. Upgrade Log4j version fro  1.2.x to 2.17.x
2. Upgrade Gradle distribution from 2.2.x to 4.8.1
3. Remove logPath functionality for Marid which is lready deprecated.