### PR TITLE
Mithril 396 : VULN fix and Java version upgrade in Opsgenie SDk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 ## 2.13.0 (December 21, 2021)
 * Gradle version increased to 4.8.1
-* Log4j updated to 2.17.0
+* Log4j updated to 2.17.2
 * Removed support of Marid logging to a path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+## 2.13.1 (April 24, 2023)
+* Java version updated to 1.8
+* Log4j updated to 2.17.2
+* httpclient updated to 4.5.14
+* jackson-databind updated to 2.14.2
+
 ## 2.13.0 (December 21, 2021)
 * Gradle version increased to 4.8.1
-* Log4j updated to 2.17.2
+* Log4j updated to 2.17.0
 * Removed support of Marid logging to a path

--- a/README.md
+++ b/README.md
@@ -32,11 +32,28 @@ dependencies {
 	compile "com.opsgenie.integration:sdk:2+"
 }
 ```
+#### Following APIs are not supported for now in this SDK. Their support will be provided soon.
+GitHub issue for this : https://github.com/opsgenie/opsgenieclient/issues/34
+* Integration API
+* Policy API
+* Contact API
+* Account API
+* User API
+* Notification Rule API
+* Notification Rule Step API
+* Team API
+* Team Member API
+* Team Routing Rule API
+* Schedule API
+* Schedule Override API
+* Escalation API
+* Who is On Call API
+* Forwarding Rule API
 
 
 ## Build
 
-**Requires JDK 1.7** 
+**Requires JDK 1.8** 
 
 This is a gradle project so you can build by running `build` task
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ subprojects {
     apply plugin: 'maven'
     apply plugin: 'project-report'
 
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     group = "com.opsgenie.client"
     version = "2.0.1-SNAPSHOT"

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ subprojects {
     targetCompatibility = 1.8
 
     group = "com.opsgenie.client"
-    version = "2.0.1-SNAPSHOT"
+    version = "2.13.1"
 
     repositories {
         mavenCentral()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,9 +9,9 @@ dependencies {
 
     compile 'bsf:bsf:2.4.0'
     compile 'org.codehaus.groovy:groovy-all:1.8.4'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.0'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.0'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.2'
+    compile group: 'org.apache.logging.log4j', name: 'log4j-slf4j-impl', version: '2.17.2'
     testCompile project(':test')
     compile 'com.opsgenie.oas:opsgenie-sdk-swagger:1.0.10'
 }

--- a/common/src/test/groovy/com/ifountain/opsgenie/client/script/AsyncScriptManagerTest.groovy
+++ b/common/src/test/groovy/com/ifountain/opsgenie/client/script/AsyncScriptManagerTest.groovy
@@ -5,8 +5,8 @@ import com.ifountain.opsgenie.client.test.util.file.TestFile
 import com.ifountain.opsgenie.client.test.util.logging.MockAppender
 import com.ifountain.opsgenie.client.test.util.logging.TestLogUtils
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Level
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.Logger
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/common/src/test/groovy/com/ifountain/opsgenie/client/script/ScriptManagerTest.groovy
+++ b/common/src/test/groovy/com/ifountain/opsgenie/client/script/ScriptManagerTest.groovy
@@ -2,7 +2,7 @@ package com.ifountain.opsgenie.client.script
 
 import com.ifountain.opsgenie.client.test.util.file.TestFile
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.Logger
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/marid/build.gradle
+++ b/marid/build.gradle
@@ -26,8 +26,8 @@ dependencies {
     compile group: 'org.json', name: 'json', version: '20090211'
     compile 'org.apache.directory.studio:org.apache.commons.lang:2.6'
     compile 'org.apache.httpcomponents:httpcore:4.2.5'
-    compile 'org.apache.httpcomponents:httpclient:4.2.5'
-    compile 'org.apache.httpcomponents:httpclient:4.2.5'
+    compile 'org.apache.httpcomponents:httpclient:4.5.14'
+    compile 'org.apache.httpcomponents:httpclient:4.5.14'
     compile 'io.netty:netty:3.6.6.Final'
     compile 'com.github.groovy-wslite:groovy-wslite:1.1.2'
     testCompile project(':test')

--- a/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/BootstrapTest.groovy
+++ b/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/BootstrapTest.groovy
@@ -25,8 +25,8 @@ import org.apache.http.conn.HttpHostConnectException
 import org.apache.http.conn.params.ConnRoutePNames
 import org.apache.http.impl.client.DefaultHttpClient
 import org.apache.http.util.EntityUtils
-import org.apache.log4j.Level
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.Logger
 import org.junit.After
 import org.junit.Before
 import org.junit.BeforeClass

--- a/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/alert/AlertActionUtilsTest.groovy
+++ b/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/alert/AlertActionUtilsTest.groovy
@@ -9,7 +9,7 @@ import com.ifountain.opsgenie.client.test.util.file.TestFile
 import com.ifountain.opsgenie.client.test.util.logging.MockAppender
 import com.opsgenie.oas.sdk.ApiClient
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.Logger
 import org.junit.After
 import org.junit.Before
 import org.junit.Test

--- a/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/alert/PubnubAlertActionListenerTest.groovy
+++ b/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/alert/PubnubAlertActionListenerTest.groovy
@@ -16,8 +16,8 @@ import com.ifountain.opsgenie.client.test.util.logging.TestLogUtils
 import com.opsgenie.oas.sdk.ApiClient
 import org.apache.commons.io.FileUtils
 import org.apache.http.HttpStatus
-import org.apache.log4j.Level
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.Logger
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Before

--- a/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/http/action/AlertActionTest.groovy
+++ b/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/http/action/AlertActionTest.groovy
@@ -9,7 +9,7 @@ import com.ifountain.opsgenie.client.test.util.RequestActionTestCase
 import com.ifountain.opsgenie.client.test.util.file.TestFile
 import com.ifountain.opsgenie.client.util.JsonUtils
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.Logger
 import org.apache.http.client.methods.HttpPost
 import org.apache.http.entity.StringEntity
 import com.ifountain.opsgenie.client.script.util.ScriptProxy

--- a/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/http/action/ScriptActionTest.groovy
+++ b/marid/src/test/groovy/com/ifountain/opsgenie/client/marid/http/action/ScriptActionTest.groovy
@@ -10,7 +10,7 @@ import org.apache.commons.io.FileUtils
 
 import com.ifountain.opsgenie.client.util.JsonUtils
 
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.Logger
 import com.ifountain.opsgenie.client.marid.MaridConfig
 import com.ifountain.opsgenie.client.OpsGenieClient
 import com.ifountain.opsgenie.client.script.OpsgenieClientApplicationConstants

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -5,8 +5,8 @@ dependencies {
     compile project(':sdk-swagger')
     compile 'org.apache.httpcomponents:httpcore:4.2.5'
     compile 'org.apache.httpcomponents:httpmime:4.2.5'
-    compile 'org.apache.httpcomponents:httpclient:4.2.5'
-    compile "com.fasterxml.jackson.core:jackson-databind:2.9.10.8"
+    compile 'org.apache.httpcomponents:httpclient:4.5.14'
+    compile "com.fasterxml.jackson.core:jackson-databind:2.14.2"
     testCompile project(':test')
 }
 

--- a/sdk/src/main/java/com/ifountain/opsgenie/client/rest/RestApiRequest.java
+++ b/sdk/src/main/java/com/ifountain/opsgenie/client/rest/RestApiRequest.java
@@ -208,8 +208,8 @@ public class RestApiRequest {
     private <T> T convertObject(byte[] json, Class<T> claz) throws IOException {
         TypeReference<RestSuccessResult<Map<?, ?>>> typeReference = new TypeReference<RestSuccessResult<Map<?, ?>>>() {
         };
-        RestSuccessResult<T> successResponse = MAPPER.readValue(json, typeReference);
-        Map<?, ?> data = (Map<?, ?>) successResponse.getData();
+        RestSuccessResult<Map<?,?>> successResponse = MAPPER.readValue(json, typeReference);
+        Map<?, ?> data = successResponse.getData();
         return MAPPER.convertValue(data, claz);
     }
 

--- a/test/src/main/groovy/com/ifountain/opsgenie/client/test/util/logging/MockAppender.groovy
+++ b/test/src/main/groovy/com/ifountain/opsgenie/client/test/util/logging/MockAppender.groovy
@@ -1,7 +1,7 @@
 package com.ifountain.opsgenie.client.test.util.logging;
 
-import org.apache.log4j.AppenderSkeleton;
-import org.apache.log4j.spi.LoggingEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.LogEvent;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -12,20 +12,20 @@ import java.util.Map;
  * @author Sezgin Kucukkaraaslan
  * @version 8/7/12 2:39 PM
  */
-public class MockAppender extends AppenderSkeleton {
+public class MockAppender extends AbstractAppender {
     private Map<String, List<String>> messages = new HashMap<String, List<String>>();
     private List<String> allMessages = new LinkedList<String>();
 
     @Override
-    protected void append(LoggingEvent loggingEvent) {
-        String level = loggingEvent.getLevel().toString();
+    public void append(LogEvent logEvent) {
+        String level = logEvent.getLevel().toString();
         List<String> levelMessages = messages.get(level);
         if (levelMessages == null) {
             levelMessages = new LinkedList<String>();
             messages.put(level, levelMessages);
         }
-        levelMessages.add(loggingEvent.getRenderedMessage());
-        allMessages.add(loggingEvent.getRenderedMessage());
+        levelMessages.add(logEvent.getRenderedMessage());
+        allMessages.add(logEvent.getRenderedMessage());
     }
 
     @Override


### PR DESCRIPTION
Changes done:
Upgraded the java version from 1.6 to 1.8
Fixed log4j VULN by upgrading the version from 2.17.0 to 2.17.2
Fixed the VULN by updating to httpclient:4.5.14 and jackson-databind:2.14.2

For Testing:
1. Gradle build is successful after making the changes.
2. Tested Alert APIs, they are working fine.
3. Tested both success and failure responses for the APIs.
4. Tested both read and write operations supported by APIs.