### PR TITLE
change from static instances to local instances of ApiClient

### DIFF
--- a/sdk/src/main/java/com/ifountain/opsgenie/client/OpsGenieClient.java
+++ b/sdk/src/main/java/com/ifountain/opsgenie/client/OpsGenieClient.java
@@ -145,7 +145,7 @@ public class OpsGenieClient implements IOpsGenieClient {
         this.jsonHttpClient.setApiKey(getApiKey());
         this.restApiClient = new RestApiClient(httpClient);
         this.restApiClient.setApiKey(getApiKey());
-        this.swaggerApiClient = Configuration.getDefaultApiClient();
+        this.swaggerApiClient = getApiClient();
         innerUserOpsGenieClient = new InnerUserOpsGenieClient(this.jsonHttpClient);
         innerGroupOpsGenieClient = new InnerGroupOpsGenieClient(this.jsonHttpClient);
         innerTeamOpsGenieClient = new InnerTeamOpsGenieClient(this.jsonHttpClient);
@@ -158,6 +158,16 @@ public class OpsGenieClient implements IOpsGenieClient {
         innerNotificationRuleOpsGenieClient = new InnerNotificationRuleOpsGenieClient(this.jsonHttpClient);
         innerAccountOpsGenieClient = new InnerAccountOpsGenieClient(this.jsonHttpClient);
 
+    }
+
+    private ApiClient getApiClient() {
+        ApiClient client = new ApiClient();
+
+        // Configure API key authorization: GenieKey
+        ApiKeyAuth genieKey = (ApiKeyAuth) client.getAuthentication("GenieKey");
+        genieKey.setApiKeyPrefix("GenieKey");
+
+        return client;
     }
 
     /**
@@ -384,15 +394,7 @@ public class OpsGenieClient implements IOpsGenieClient {
     }
 
     public AlertApi alertV2() {
-        // Configure API key authorization: GenieKey
-        ApiKeyAuth genieKey = (ApiKeyAuth) swaggerApiClient.getAuthentication("GenieKey");
-
-        if (StringUtils.isNotEmpty(getApiKey())) {
-            genieKey.setApiKey(getApiKey());
-        }
-        genieKey.setApiKeyPrefix("GenieKey");
-
-        return new AlertApi();
+        return new AlertApi(swaggerApiClient);
     }
 
     /**

--- a/sdk/src/test/groovy/com/ifountain/opsgenie/client/AlertV2OpsGenieClientTest.groovy
+++ b/sdk/src/test/groovy/com/ifountain/opsgenie/client/AlertV2OpsGenieClientTest.groovy
@@ -1,0 +1,43 @@
+package com.ifountain.opsgenie.client;
+
+import com.ifountain.opsgenie.client.http.HttpTestRequestListener
+import com.ifountain.opsgenie.client.swagger.auth.ApiKeyAuth;
+import com.ifountain.opsgenie.client.test.util.OpsGenieClientTestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+class AlertV2OpsGenieClientTest extends OpsGenieClientTestCase implements HttpTestRequestListener {
+    @Test
+    void testApiKeySetAsExpected() throws Exception {
+        // Given
+        def client1 = new OpsGenieClient()
+        client1.apiKey = "secret-1"
+
+        def client2 = new OpsGenieClient()
+        client2.apiKey = "secret-2"
+
+        // When
+        def api1 = client1.alertV2()
+        def api2 = client2.alertV2()
+
+        // Then
+        assertEquals("secret-1", ((ApiKeyAuth) api1.getApiClient().getAuthentication("GenieKey")).apiKey)
+        assertEquals("secret-2", ((ApiKeyAuth) api2.getApiClient().getAuthentication("GenieKey")).apiKey)
+    }
+
+    @Test
+    void testApplyHeaders() throws Exception {
+        // Given
+        def client = new OpsGenieClient()
+        client.apiKey = "secret"
+
+        def headers = new HashMap<String, String>()
+
+        // When
+        ((ApiKeyAuth) client.alertV2().apiClient.getAuthentication("GenieKey")).applyToParams([], headers)
+
+        // Then
+        assertEquals("GenieKey secret", headers["Authorization"])
+    }
+}

--- a/test/build.gradle
+++ b/test/build.gradle
@@ -8,4 +8,5 @@ dependencies {
     compile 'org.apache.directory.studio:org.apache.commons.lang:2.6'
     compile 'org.littleshoot:littleproxy:0.5.OG-atlassian-hosted'
     compile 'junit:junit:4.12'
+    compile 'log4j:log4j:1.2.16'
 }


### PR DESCRIPTION
There's a bug that arises when multiple instances of OpsGenieClient are created when using the swagger generated Alert API client.

Since under the hood the OpsGenieClient and AlertApi classes both default to a static instance of ApiClient, setting the API key changes the API key for all instances of OpsGenieClient.

This change simply stops uses the static instance in favor of creating a new instance of ApiClient per instance of OpsGenieClient.